### PR TITLE
Fix a bug that stopped Manchester Users from logging in

### DIFF
--- a/src/main/java/DepotSystem.java
+++ b/src/main/java/DepotSystem.java
@@ -117,7 +117,6 @@ public class DepotSystem
 					exit = true;
 					break;
 				}
-				depotNo++;
 			}
 		} while (!exit);
 		depotMenu();


### PR DESCRIPTION
The for loop was iterating too many times causing it to break and spiral into a infinite loop